### PR TITLE
Simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,16 +43,12 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
-      - name: Create or update GitHub Release
+      - name: Create GitHub Release
         run: |
-          if gh release view ${{ github.ref_name }} > /dev/null 2>&1; then
-            gh release upload ${{ github.ref_name }} githop-*.tar.gz --clobber
-          else
-            gh release create ${{ github.ref_name }} \
-              --title "${{ github.ref_name }}" \
-              --generate-notes \
-              githop-*.tar.gz
-          fi
+          gh release create ${{ github.ref_name }} \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            githop-*.tar.gz
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Remove `gh release view` / `gh release upload --clobber` fallback from release workflow
- Use only `gh release create` since tag re-pushing is not part of the release process
- If a release fails, the correct approach is to fix forward with a new patch version

## Test plan

- [ ] Next tag push creates a GitHub Release normally